### PR TITLE
Gen: allow the use of images as tables

### DIFF
--- a/generator/src/html/Generator.hx
+++ b/generator/src/html/Generator.hx
@@ -327,6 +327,27 @@ class Generator {
 				writeRow(r, false);
 			buf.add("</table>\n</section>\n");
 			return buf.toString();
+		case DImgTable(no, size, caption, path):
+			idc.table = v.id.sure();
+			noc.table = no;
+			var no = noc.join(false, ".", chapter, table);
+			var id = idc.join(true, ".", table);
+			if (Context.draft) {
+				return '
+					<section class="img-block ${sizeToClass(size)}">
+					<h5 id="$id">Table $no$QUAD${genh(caption)} <em>$DRAFT_IMG_PLACEHOLDER_COPYRIGHT</em></h5>
+					<img src="$DRAFT_IMG_PLACEHOLDER"/>
+					</section>
+				'.doctrim() + "\n";
+			} else {
+				var p = saveAsset(path);
+				return '
+					<section class="img-block ${sizeToClass(size)}">
+					<h5 id="$id">Table $no$QUAD${genh(caption)}</h5>
+					<img src="$p"/>
+					</section>
+				'.doctrim() + "\n";
+			}
 		case DList(numbered, li):
 			var buf = new StringBuf();
 			var tag = numbered ? "ol" : "ul";

--- a/generator/src/parser/Ast.hx
+++ b/generator/src/parser/Ast.hx
@@ -40,6 +40,7 @@ enum VDef {
 	SubSubSection(name:HElem);
 	Figure(size:BlobSize, path:String, caption:HElem, copyright:HElem);
 	Table(size:BlobSize, caption:HElem, header:TableRow, rows:Array<TableRow>);  // copyright/source?
+	ImgTable(size:BlobSize, caption:HElem, path:String);  // copyright/source?
 	Quotation(text:HElem, by:HElem);
 	List(numered:Bool, items:Array<VElem>);
 	Box(name:HElem, contents:VElem);

--- a/generator/src/tests/Test_03_Parser.hx
+++ b/generator/src/tests/Test_03_Parser.hx
@@ -606,6 +606,10 @@ class Test_03_Parser {
 					@wrap(6,0)Paragraph(@len(1)Word("2")) ])] ])),
 			parse("\\begintable{a}\\header\\col x\\col y\\row\\col list\\col \\item 1\\item 2\\endtable"));
 
+		Assert.same(
+			expand(@wrap(12,9)ImgTable(TextWidth,@len(1)Word("a"),@skip(1)@len(16)"x.svg")),
+			parse("\\begintable{a}\\useimage{x.svg}\\endtable"));
+
 		parsingError("\\endtable", UnexpectedCommand, ~/\\endtable/);
 	}
 

--- a/generator/src/tex/Generator.hx
+++ b/generator/src/tex/Generator.hx
@@ -151,6 +151,23 @@ class Generator {
 			idc.table = v.id.sure();
 			var id = idc.join(true, ":", chapter, table);
 			return LargeTable.gen(v, id, this, at, idc);
+		case DImgTable(no, size, caption, path):
+			idc.table = v.id.sure();
+			var id = idc.join(true, ":", chapter, table);
+			path = sys.FileSystem.absolutePath(path);  // FIXME maybe move to transform
+			// TODO handle size
+			// TODO enable on XeLaTeX too
+			// FIXME escape path
+			// FIXME label
+			return '
+			\\ifxetex
+				% disabled for now
+			\\else
+				{  % group required to avoid fignote settings escaping
+					\\tabletitle{$no}{${genh(caption)}}\n\\label{$id}\n
+					\\img{\\hsize}{$path}
+				}
+			\\fi'.doctrim() + "\n\n";  // FIXME use more neutral names
 		case DList(numbered, li):
 			var buf = new StringBuf();
 			var env = numbered ? "enumerate" : "itemize";

--- a/generator/src/tex/LargeTable.hx
+++ b/generator/src/tex/LargeTable.hx
@@ -54,7 +54,7 @@ class LargeTable {
 				cnt += pseudoTypeset(i);
 			cnt/li.length;
 		case DFigure(_, _, _, caption, cright): TBL_MARK_COST + pseudoHTypeset(caption) + SPACE_COST + pseudoHTypeset(cright);
-		case DTable(_), DBox(_): BAD_COST; // not allowed (for now?)
+		case DTable(_), DImgTable(_), DBox(_): BAD_COST; // not allowed (for now?)
 		case DQuotation(text, by): QUOTE_COST + pseudoHTypeset(text) + QUOTE_COST + LINE_BREAK_COST + EM_DASH_COST + pseudoHTypeset(by);
 		case DList(numbered, li):
 			var markCost = BULLET_COST + SPACE_COST;

--- a/generator/src/transform/DocumentTools.hx
+++ b/generator/src/transform/DocumentTools.hx
@@ -20,7 +20,7 @@ class DocumentTools {
 		case DElemList(items), DList(_, items):
 			for (i in items)
 				f(i);
-		case DLaTeXPreamble(_), DLaTeXExport(_), DHtmlApply(_), DFigure(_), DQuotation(_), DCodeBlock(_), DParagraph(_), DEmpty:
+		case DLaTeXPreamble(_), DLaTeXExport(_), DHtmlApply(_), DFigure(_), DImgTable(_), DQuotation(_), DCodeBlock(_), DParagraph(_), DEmpty:
 		}
 	}
 
@@ -49,7 +49,7 @@ class DocumentTools {
 				DBox(no, name, f(contents));
 			case DList(numbered, items):
 				DList(numbered, [for (i in items) f(i)]);
-			case DLaTeXPreamble(_), DLaTeXExport(_), DHtmlApply(_), DFigure(_), DQuotation(_), DCodeBlock(_), DParagraph(_), DEmpty:
+			case DLaTeXPreamble(_), DLaTeXExport(_), DHtmlApply(_), DFigure(_), DImgTable(_), DQuotation(_), DCodeBlock(_), DParagraph(_), DEmpty:
 				v.def;
 			}
 		}

--- a/generator/src/transform/NewDocument.hx
+++ b/generator/src/transform/NewDocument.hx
@@ -24,6 +24,7 @@ enum DDef {
 	DBox(no:Int, name:HElem, children:DElem);
 	DFigure(no:Int, size:BlobSize, path:String, caption:HElem, copyright:HElem);
 	DTable(no:Int, size:BlobSize, caption:HElem, header:Array<DElem>, rows:Array<Array<DElem>>);
+	DImgTable(no:Int, size:BlobSize, caption:HElem, path:String);
 	DList(numbered:Bool, li:Array<DElem>);
 	DCodeBlock(cte:String);
 	DQuotation(text:HElem, by:HElem);

--- a/generator/src/transform/NewTransform.hx
+++ b/generator/src/transform/NewTransform.hx
@@ -191,6 +191,10 @@ class NewTransform {
 			var dheader = header.map(vertical.bind(_, null, idc, noc));
 			var drows = rows.map(function (r) return r.map(vertical.bind(_, null, idc, noc)));
 			return mkd(DTable(no, size, caption, dheader, drows), v.pos, id);
+		case ImgTable(size, horizontal(_) => caption, path):
+			var id = idc.table = genId(caption);
+			var no = ++noc.table;
+			return mkd(DImgTable(no, size, caption, path), v.pos, id);
 		case List(numbered, li):
 			return mkd(DList(numbered, [ for (i in li) vertical(i, siblings, idc, noc) ]), v.pos);
 		case CodeBlock(cte):
@@ -226,7 +230,7 @@ class NewTransform {
 		assert(d != null);
 		assert(d.def != null);
 		var def = switch d.def {
-		case DHtmlApply(_), DLaTeXPreamble(_), DLaTeXExport(_), DFigure(_), DCodeBlock(_), DQuotation(_), DEmpty:
+		case DHtmlApply(_), DLaTeXPreamble(_), DLaTeXExport(_), DFigure(_), DImgTable(_), DCodeBlock(_), DQuotation(_), DEmpty:
 			d.def;
 		case DVolume(no, name, children):
 			DVolume(no, name, clean(children));

--- a/generator/src/transform/Transform.hx
+++ b/generator/src/transform/Transform.hx
@@ -59,6 +59,7 @@ class Transform {
 		case DParagraph(text): TParagraph(text);
 		case DElemList(li): TElemList([ for (i in li) compat(i, id) ]);
 		case DEmpty: null;
+		case DImgTable(_): null;  // unsupported new syntax
 		}
 		return mk(def, d.pos);
 	}

--- a/guide/08-traffic-impact-assessment/86-methodologies-and-performance-measures.src
+++ b/guide/08-traffic-impact-assessment/86-methodologies-and-performance-measures.src
@@ -147,9 +147,9 @@ is based on several factors such as:
 
 \item Pedestrian delay.
 
-\'TODO: Change to fake table '\
-\figure[medium]{assets/image3.png}{Pedestrian LOS Criteria.}{Highway Capacity Manual, 2010.}
-
+\begintable{Pedestrian LOS Criteria} \' MAYBE include src? src := Highway Capacity Manual, 2010 '\
+\useimage{assets/image3.png}
+\endtable
 
 As pointed out earlier, the values used for the actual scoring outlined in the *HCM* are not necessarily 
 internationally applicable. However, the methodology provides a framework within which calibration for 


### PR DESCRIPTION
Syntax:

Inside a `\begintable`–`\endtable` block, add `\useimage{<path>}`
instead of providing header and data rows.

Example:

```
\begintable{Pedestrian LOS Criteria} \' MAYBE include src? src := Highway Capacity Manual, 2010 '\
\useimage{assets/image3.png}
\endtable
```

(chapter 8, section 6)
