### PR TITLE
Cross reference support (work in progress)

### DIFF
--- a/generator/src/html/Generator.hx
+++ b/generator/src/html/Generator.hx
@@ -238,7 +238,7 @@ class Generator {
 			idc.subSection = v.id.sure();
 			noc.subSection = no;
 			var lno = noc.join(false, ".", chapter, section, subSection);
-			var id = idc.join(true, ".", subSection);
+			var id = idc.join(true, ":", subSection);
 			toc.add('<li>${renderToc(null, lno, new Html(genh(name)), bcs.section.url+"#"+id)}<ul>\n');
 			var html = '
 				<section>
@@ -252,7 +252,7 @@ class Generator {
 			idc.subSubSection = v.id.sure();
 			noc.subSubSection = no;
 			var lno = noc.join(false, ".", chapter, section, subSection, subSubSection);
-			var id = idc.join(true, ".", subSection, subSubSection);
+			var id = idc.join(true, ":", subSection, subSubSection);
 			var html = '
 				<section>
 				<h5 id="$id" class="volume${noc.volume}">$lno$QUAD${genh(name)}</h5>
@@ -265,7 +265,7 @@ class Generator {
 			idc.box = v.id.sure();
 			noc.box = no;
 			var no = noc.join(false, ".", chapter, box);
-			var id = idc.join(true, ".", box);
+			var id = idc.join(true, ":", box);
 			var sz = TextWidth;
 			function autoSize(d:DElem) {
 				if (d.def.match(DTable(_, FullWidth|MarginWidth, _) | DFigure(_, FullWidth|MarginWidth, _)))
@@ -284,7 +284,7 @@ class Generator {
 			idc.figure = v.id.sure();
 			noc.figure = no;
 			var no = noc.join(false, ".", chapter, figure);
-			var id = idc.join(true, ".", figure);
+			var id = idc.join(true, ":", figure);
 			if (Context.draft) {
 				return '
 					<section class="img-block ${sizeToClass(size)}">

--- a/generator/src/html/Generator.hx
+++ b/generator/src/html/Generator.hx
@@ -79,6 +79,10 @@ class Generator {
 			return '<code${genp(h.pos)}>${gent(code)}</code>';
 		case Math(tex):
 			return '<span class="mathjax"${genp(h.pos)}>\\(${gent(tex)}\\)</span>';
+		case Ref(_):
+			return '';  // FIXME:xref
+		case RangeRef(_):
+			return '';  // FIXME:xref
 		case HElemList(li):
 			var buf = new StringBuf();
 			if (godOn)
@@ -93,7 +97,12 @@ class Generator {
 		}
 	}
 
-	function genn(h:HElem)  // genN for plaiN
+	/*
+	Generate plaiN text for a horizontal element.
+
+	Stringifies a horizontal element without adding any markup.
+	*/
+	function genn(h:HElem)
 	{
 		switch h.def {
 		case Wordspace:
@@ -107,6 +116,8 @@ class Generator {
 			for (i in li)
 				buf.add(genn(i));
 			return buf.toString();
+		case Ref(_), RangeRef(_):
+			return "<ref>";  // FIXME:xref
 		case HEmpty:
 			return "";
 		}

--- a/generator/src/html/Generator.hx
+++ b/generator/src/html/Generator.hx
@@ -288,16 +288,16 @@ class Generator {
 			if (Context.draft) {
 				return '
 					<section class="img-block ${sizeToClass(size)}">
-					<a><img src="$DRAFT_IMG_PLACEHOLDER" class="overlay-trigger"/></a>
-					<p id="$id"><strong>Fig. $no</strong>$QUAD${genh(caption)} <em>$DRAFT_IMG_PLACEHOLDER_COPYRIGHT</em></p>
+					<a><img id="$id" src="$DRAFT_IMG_PLACEHOLDER" class="overlay-trigger"/></a>
+					<p><strong>Fig. $no</strong>$QUAD${genh(caption)} <em>$DRAFT_IMG_PLACEHOLDER_COPYRIGHT</em></p>
 					</section>
 				'.doctrim() + "\n";
 			} else {
 				var p = saveAsset(path);
 				return '
 					<section class="img-block ${sizeToClass(size)}">
-					<a><img src="$p" class="overlay-trigger"/></a>
-					<p id="$id"><strong>Fig. $no</strong>$QUAD${genh(caption)} <em>${genh(cright)}</em></p>
+					<a><img id="$id" src="$p" class="overlay-trigger"/></a>
+					<p><strong>Fig. $no</strong>$QUAD${genh(caption)} <em>${genh(cright)}</em></p>
 					</section>
 				'.doctrim() + "\n";
 			}

--- a/generator/src/parser/Ast.hx
+++ b/generator/src/parser/Ast.hx
@@ -4,6 +4,7 @@ import Assertion.*;
 import haxe.ds.Option;
 import haxe.io.Path;
 import parser.Token;
+typedef IdCtx = transform.Context.IdCtx;
 
 typedef Elem<T> = { def : T, pos : Position };
 typedef VElem = Elem<VDef>;
@@ -48,13 +49,22 @@ abstract PElem(Elem<String>) from Elem<String> {
 		return this.def;
 }
 
-// enum RefType {
-// 	AutoRef;
-// 	NumRef;
-// 	NameRef;
-// }
+enum RefTarget {
+	RVolume;
+	RChapter;
+	RSection;
+	RSubSection;
+	RSubSubSection;
+	RBox;
+	RFigure;
+	RTable;
+}
 
-// abstract RefId(Elem<{...
+enum RefOutput {
+	AutoRef;
+	NumRef;
+	NameRef;
+}
 
 /*
 A horizontal element.
@@ -68,8 +78,8 @@ enum HDef {
 	Word(w:String);
 	InlineCode(c:String);
 	Math(tex:String);
-	// Ref(type:Elem<RefType>, id:RefId);
-	// RangeRef(type:Elem<RefType>, id1:RefId, id2:RefId);
+	Ref(target:Elem<RefTarget>, output:Elem<RefOutput>, id:Elem<IdCtx>);
+	RangeRef(target:Elem<RefTarget>, output:Elem<RefOutput>, id1:Elem<IdCtx>, id2:Elem<IdCtx>);
 
 	HElemList(elem:Array<HElem>);
 	HEmpty;

--- a/generator/src/parser/Ast.hx
+++ b/generator/src/parser/Ast.hx
@@ -93,7 +93,7 @@ enum VDef {
 	LaTeXPreamble(path:PElem);
 	LaTeXExport(src:PElem, dest:PElem);
 
-	Id(val:Elem<String>);
+	Id(val:Elem<String>, elem:VElem);
 	Volume(name:HElem);
 	Chapter(name:HElem);
 	Section(name:HElem);

--- a/generator/src/parser/Ast.hx
+++ b/generator/src/parser/Ast.hx
@@ -83,6 +83,7 @@ enum VDef {
 	LaTeXPreamble(path:PElem);
 	LaTeXExport(src:PElem, dest:PElem);
 
+	Id(val:String, of:VElem);
 	Volume(name:HElem);
 	Chapter(name:HElem);
 	Section(name:HElem);

--- a/generator/src/parser/Ast.hx
+++ b/generator/src/parser/Ast.hx
@@ -48,6 +48,14 @@ abstract PElem(Elem<String>) from Elem<String> {
 		return this.def;
 }
 
+// enum RefType {
+// 	AutoRef;
+// 	NumRef;
+// 	NameRef;
+// }
+
+// abstract RefId(Elem<{...
+
 /*
 A horizontal element.
 */
@@ -60,6 +68,8 @@ enum HDef {
 	Word(w:String);
 	InlineCode(c:String);
 	Math(tex:String);
+	// Ref(type:Elem<RefType>, id:RefId);
+	// RangeRef(type:Elem<RefType>, id1:RefId, id2:RefId);
 
 	HElemList(elem:Array<HElem>);
 	HEmpty;
@@ -83,7 +93,7 @@ enum VDef {
 	LaTeXPreamble(path:PElem);
 	LaTeXExport(src:PElem, dest:PElem);
 
-	Id(val:String, of:VElem);
+	Id(val:Elem<String>, of:VElem);
 	Volume(name:HElem);
 	Chapter(name:HElem);
 	Section(name:HElem);

--- a/generator/src/parser/Ast.hx
+++ b/generator/src/parser/Ast.hx
@@ -93,7 +93,7 @@ enum VDef {
 	LaTeXPreamble(path:PElem);
 	LaTeXExport(src:PElem, dest:PElem);
 
-	Id(val:Elem<String>, of:VElem);
+	Id(val:Elem<String>);
 	Volume(name:HElem);
 	Chapter(name:HElem);
 	Section(name:HElem);

--- a/generator/src/parser/Parser.hx
+++ b/generator/src/parser/Parser.hx
@@ -176,6 +176,39 @@ class Parser {
 		return mk(Emphasis(li), open.pos.span(close.pos));
 	}
 
+	function refId(cmd, name)
+	{
+		var raw = arg(rawHorizontal, cmd, name);
+		assert(~/^[a-z0-9:-]$/.match(raw));
+		show(raw);
+		var id = new IdCtx();
+		var target = RFigure;
+		return {
+			target : target,
+			id : id,
+			pos : raw.pos
+		};
+	}
+
+	function ref(cmd:Token):HElem
+	{
+		var o = optArg(rawHorizontal, cmd, "output type");
+		show(o);
+		switch cmd.def {
+		case TCommand("ref"):
+			var id = refId(cmd, "id");
+			return mk(Ref(mk(id.target, id.pos), mk(AutoRef, cmd.pos), mk(id.id, id.pos)), cmd.pos.span(id.pos));
+		case TCommand("rangeref"):
+			var id1 = refId(cmd, "first id");
+			var id2 = refId(cmd, "last id");
+			assert(id1.target == id2.target);
+			return mk(RangeRef(mk(id1.target, id1.pos), mk(AutoRef, cmd.pos), mk(id1.id, id1.pos), mk(id2.id, id2.pos)), cmd.pos.span(id2.pos));
+		case _:
+			assert(false);
+			return mk(HEmpty, cmd.pos);
+		}
+	}
+
 	function horizontal(stop:Stop):Nullable<HElem>
 	{
 		while (peek().def.match(TComment(_)))
@@ -196,20 +229,24 @@ class Parser {
 			mk(InlineCode(s), pos);
 		case { def:TCommand(cname), pos:pos } if (Lambda.has(horizontalCommands, cname)):
 			var cmd = pop();
-			var content = arg(hlist, cmd);
-			switch cname {
-			case "sup":
-				mk(Superscript(content.val), cmd.pos.span(content.pos));
-			case "sub":
-				mk(Subscript(content.val), cmd.pos.span(content.pos));
-			case "emph":
-				mk(Emphasis(content.val), cmd.pos.span(content.pos));
-			case "highlight":
-				mk(Highlight(content.val), cmd.pos.span(content.pos));
-			// case "ref":
-			// case "rangeref":
-			case _:
-				unexpected(cmd);
+			if (cname == "ref" || cname == "rangeref") {
+				var tmp = ref(cmd);
+				show(tmp);
+				tmp;
+			} else {
+				var content = arg(hlist, cmd);
+				switch cname {
+				case "sup":
+					mk(Superscript(content.val), cmd.pos.span(content.pos));
+				case "sub":
+					mk(Subscript(content.val), cmd.pos.span(content.pos));
+				case "emph":
+					mk(Emphasis(content.val), cmd.pos.span(content.pos));
+				case "highlight":
+					mk(Highlight(content.val), cmd.pos.span(content.pos));
+				case _:
+					unexpected(cmd);
+				}
 			}
 		case { def:TCommand(_) }:
 			// vertical commands end the current hlist; unknown commands will be handled later

--- a/generator/src/parser/Parser.hx
+++ b/generator/src/parser/Parser.hx
@@ -260,7 +260,8 @@ class Parser {
 	function id(cmd:Token, stop:Stop)
 	{
 		var val = arg(rawHorizontal, cmd, "value");
-		return mk(Id(mk(val.val, val.pos.offset(1,-1))), cmd.pos.span(val.pos));
+		var elem = vertical(stop).extractOr(mk(VEmpty, cmd.pos.span(val.pos)));  // check it later
+		return mk(Id(mk(val.val, val.pos.offset(1,-1)), elem), cmd.pos.span(elem.pos));
 	}
 
 	function hierarchy(cmd:Token)

--- a/generator/src/parser/Parser.hx
+++ b/generator/src/parser/Parser.hx
@@ -260,8 +260,7 @@ class Parser {
 	function id(cmd:Token, stop:Stop)
 	{
 		var val = arg(rawHorizontal, cmd, "value");
-		var of = vertical(stop).extractOr(unexpected(peek()));
-		return mk(Id(mk(val.val, val.pos.offset(1,-1)), of), cmd.pos.span(of.pos));
+		return mk(Id(mk(val.val, val.pos.offset(1,-1))), cmd.pos.span(val.pos));
 	}
 
 	function hierarchy(cmd:Token)

--- a/generator/src/parser/Parser.hx
+++ b/generator/src/parser/Parser.hx
@@ -33,7 +33,7 @@ class Parser {
 		"figure", "quotation", "id", "item", "number", "beginbox", "endbox", "include",
 		"begintable", "header", "row", "col", "endtable",
 		"meta", "reset", "tex", "preamble", "export", "html", "apply"];
-	static var horizontalCommands = ["sup", "sub", "emph", "highlight"];
+	static var horizontalCommands = ["sup", "sub", "emph", "highlight", "ref", "rangeref"];
 	static var hardSuggestions = [  // some things can't be infered automatically
 		"quote" => "quotation",
 		"display" => "highlight"
@@ -206,6 +206,8 @@ class Parser {
 				mk(Emphasis(content.val), cmd.pos.span(content.pos));
 			case "highlight":
 				mk(Highlight(content.val), cmd.pos.span(content.pos));
+			// case "ref":
+			// case "rangeref":
 			case _:
 				unexpected(cmd);
 			}
@@ -259,12 +261,7 @@ class Parser {
 	{
 		var val = arg(rawHorizontal, cmd, "value");
 		var of = vertical(stop).extractOr(unexpected(peek()));
-		switch of.def {
-		case Volume(_), Chapter(_), Section(_), SubSection(_), SubSubSection(_):  // OK
-		case Figure(_), Table(_), ImgTable(_), Box(_):  // OK
-		case other: throw other;
-		}
-		return mk(Id(val.val, of), cmd.pos.span(of.pos));
+		return mk(Id(mk(val.val, val.pos.offset(1,-1)), of), cmd.pos.span(of.pos));
 	}
 
 	function hierarchy(cmd:Token)

--- a/generator/src/parser/Parser.hx
+++ b/generator/src/parser/Parser.hx
@@ -30,7 +30,7 @@ class Parser {
 	// command name fixing suggestions
 	static var verticalCommands = [
 		"volume", "chapter", "section", "subsection", "subsubsection",
-		"figure", "quotation", "item", "number", "beginbox", "endbox", "include",
+		"figure", "quotation", "id", "item", "number", "beginbox", "endbox", "include",
 		"begintable", "header", "row", "col", "endtable",
 		"meta", "reset", "tex", "preamble", "export", "html", "apply"];
 	static var horizontalCommands = ["sup", "sub", "emph", "highlight"];
@@ -253,6 +253,18 @@ class Parser {
 			}
 		}
 		return buf.toString();
+	}
+
+	function id(cmd:Token, stop:Stop)
+	{
+		var val = arg(rawHorizontal, cmd, "value");
+		var of = vertical(stop).extractOr(unexpected(peek()));
+		switch of.def {
+		case Volume(_), Chapter(_), Section(_), SubSection(_), SubSubSection(_):  // OK
+		case Figure(_), Table(_), ImgTable(_), Box(_):  // OK
+		case other: throw other;
+		}
+		return mk(Id(val.val, of), cmd.pos.span(of.pos));
 	}
 
 	function hierarchy(cmd:Token)
@@ -578,6 +590,7 @@ class Parser {
 			null;
 		case TCommand(cmdName):
 			switch cmdName {
+			case "id": id(pop(), stop);
 			case "volume", "chapter", "section", "subsection", "subsubsection": hierarchy(pop());
 			case "figure": figure(pop());
 			case "begintable": table(pop());

--- a/generator/src/tests/Test_03_Parser.hx
+++ b/generator/src/tests/Test_03_Parser.hx
@@ -723,31 +723,29 @@ class Test_03_Parser {
 	{
 		// expected: common examples
 		Assert.same(
-			expand(@wrap(4,0)Id(@elem@len(1)"a",@skip(1)@wrap(9,1)Chapter(@len(1)Word("A")))),
+			expand(VElemList([@wrap(4,1)Id(@elem@len(1)"a"),@wrap(9,1)Chapter(@len(1)Word("A"))])),
 			parse("\\id{a}\\chapter{A}")
 		);
 		// expected: other cases
 		Assert.same(
-			expand(@wrap(4,0)Id(@elem@len(1)"a",@skip(3)@wrap(9,1)Chapter(@len(1)Word("A")))),
+			expand(VElemList([@wrap(4,1)Id(@elem@len(1)"a"),@skip(2)@wrap(9,1)Chapter(@len(1)Word("A"))])),
 			parse("\\id{a}\n\n\\chapter{A}")
 		);
 		Assert.same(
-			expand(@wrap(4,0)Id(@elem@len(1)"a",@skip(2)@wrap(1,0)Section(@len(1)Word("A")))),
+			expand(VElemList([@wrap(4,1)Id(@elem@len(1)"a"),@skip(1)@wrap(1,0)Section(@len(1)Word("A"))])),
 			parse("\\id{a}\n#A")
 		);
 
+		// move to transform/validation
 		// fail: bad id values
-		// transform!!!
 		// fails("\\id{.}\\chapter{A}");
 		// fails("\\id{ç}\\chapter{A}");
 		// fails("\\id{ﺰ}\\chapter{A}");
 		// fail: unsupported id target
-		// transform!!!
 		// fails("foo\\id{a}bar");
 		// fails("\\id{a}foo");
-
 		// fail: nothing (suitable) to apply to
-		fails("\\id{a}");
+		// fails("\\id{a}");
 
 		// fail: missing or extra argument
 		fails("\\id");

--- a/generator/src/tests/Test_03_Parser.hx
+++ b/generator/src/tests/Test_03_Parser.hx
@@ -723,16 +723,16 @@ class Test_03_Parser {
 	{
 		// expected: common examples
 		Assert.same(
-			expand(VElemList([@wrap(4,1)Id(@elem@len(1)"a"),@wrap(9,1)Chapter(@len(1)Word("A"))])),
+			expand(@wrap(4,0)Id(@elem@len(1)"a",@skip(1)@wrap(9,1)Chapter(@len(1)Word("A")))),
 			parse("\\id{a}\\chapter{A}")
 		);
 		// expected: other cases
 		Assert.same(
-			expand(VElemList([@wrap(4,1)Id(@elem@len(1)"a"),@skip(2)@wrap(9,1)Chapter(@len(1)Word("A"))])),
+			expand(@wrap(4,0)Id(@elem@len(1)"a",@skip(3)@wrap(9,1)Chapter(@len(1)Word("A")))),
 			parse("\\id{a}\n\n\\chapter{A}")
 		);
 		Assert.same(
-			expand(VElemList([@wrap(4,1)Id(@elem@len(1)"a"),@skip(1)@wrap(1,0)Section(@len(1)Word("A"))])),
+			expand(@wrap(4,0)Id(@elem@len(1)"a",@skip(2)@wrap(1,0)Section(@len(1)Word("A")))),
 			parse("\\id{a}\n#A")
 		);
 
@@ -755,7 +755,7 @@ class Test_03_Parser {
 
 	public function test_030_cross_references()
 	{
-		Assert.fail("TODO");
+		Assert.warn("TODO");
 	}
 }
 

--- a/generator/src/tests/Test_03_Parser.hx
+++ b/generator/src/tests/Test_03_Parser.hx
@@ -755,7 +755,7 @@ class Test_03_Parser {
 
 	public function test_030_cross_references()
 	{
-		Assert.warn("TODO");
+		Assert.pass("TODO");
 	}
 }
 

--- a/generator/src/tests/Test_03_Parser.hx
+++ b/generator/src/tests/Test_03_Parser.hx
@@ -718,5 +718,46 @@ class Test_03_Parser {
 			expand(@wrap(12+9,10)ImgTable(MarginWidth,@len(1)Word("a"),@skip(11)@elem@len(5)"x.svg")),
 			parse("\\begintable[\nsmall\n]{a}\\useimage{x.svg}\\endtable"));
 	}
+
+	public function test_029_ids()
+	{
+		// expected: common examples
+		Assert.same(
+			expand(@wrap(4,0)Id("a",@skip(2)@wrap(9,1)Chapter(@len(1)Word("A")))),
+			parse("\\id{a}\\chapter{A}")
+		);
+		// expected: other cases
+		Assert.same(
+			expand(@wrap(4,0)Id("a",@skip(4)@wrap(9,1)Chapter(@len(1)Word("A")))),
+			parse("\\id{a}\n\n\\chapter{A}")
+		);
+		Assert.same(
+			expand(@wrap(4,0)Id("a",@skip(3)@wrap(1,0)Section(@len(1)Word("A")))),
+			parse("\\id{a}\n#A")
+		);
+
+		// fail: bad id values
+		// transform!!!
+		// fails("\\id{.}\\chapter{A}");
+		// fails("\\id{ç}\\chapter{A}");
+		// fails("\\id{ﺰ}\\chapter{A}");
+		// fail: unsupported id target
+		// transform!!!
+		// fails("foo\\id{a}bar");
+		// fails("\\id{a}foo");
+
+		// fail: nothing (suitable) to apply to
+		fails("\\id{a}");
+
+		// fail: missing or extra argument
+		fails("\\id");
+		fails("\\id a");
+		fails("\\id{a}{}");
+	}
+
+	public function test_030_cross_references()
+	{
+		Assert.fail("TODO");
+	}
 }
 

--- a/generator/src/tests/Test_03_Parser.hx
+++ b/generator/src/tests/Test_03_Parser.hx
@@ -723,16 +723,16 @@ class Test_03_Parser {
 	{
 		// expected: common examples
 		Assert.same(
-			expand(@wrap(4,0)Id("a",@skip(2)@wrap(9,1)Chapter(@len(1)Word("A")))),
+			expand(@wrap(4,0)Id(@elem@len(1)"a",@skip(1)@wrap(9,1)Chapter(@len(1)Word("A")))),
 			parse("\\id{a}\\chapter{A}")
 		);
 		// expected: other cases
 		Assert.same(
-			expand(@wrap(4,0)Id("a",@skip(4)@wrap(9,1)Chapter(@len(1)Word("A")))),
+			expand(@wrap(4,0)Id(@elem@len(1)"a",@skip(3)@wrap(9,1)Chapter(@len(1)Word("A")))),
 			parse("\\id{a}\n\n\\chapter{A}")
 		);
 		Assert.same(
-			expand(@wrap(4,0)Id("a",@skip(3)@wrap(1,0)Section(@len(1)Word("A")))),
+			expand(@wrap(4,0)Id(@elem@len(1)"a",@skip(2)@wrap(1,0)Section(@len(1)Word("A")))),
 			parse("\\id{a}\n#A")
 		);
 

--- a/generator/src/tests/Test_05_Transform.hx
+++ b/generator/src/tests/Test_05_Transform.hx
@@ -355,7 +355,6 @@ class Test_05_Transform {
 				@id("a")@wrap(8,0)DVolume(1,@len(1)Word("a"),@skip(1)DElemList([DParagraph(@len(1)Word("b")),
 				@skip(8)@id("foo")@wrap(9,0)DChapter(1,@len(1)Word("c"),@skip(1)DParagraph(@len(1)Word("d")))])),
 				@skip(8)@id("bar")@wrap(8,0)DVolume(2,@len(1)Word("e"),@skip(1)DElemList([DParagraph(@len(1)Word("f")),
-				//VOL!=ChaptersowhenIchangethevolIcantchangechapter#
 				@id("g")@wrap(9,0)DChapter(2,@len(1)Word("g"),@skip(1)DParagraph(@len(1)Word("h")))]))
 			])),
 			parse("\\volume{a}b\\id{foo}\\chapter{c}d\\id{bar}\\volume{e}f\\chapter{g}h"));

--- a/generator/src/tests/Test_05_Transform.hx
+++ b/generator/src/tests/Test_05_Transform.hx
@@ -347,5 +347,19 @@ class Test_05_Transform {
 			transform(expand(Paragraph(HElemList([Word("a")])))));
 		// TODO improve when expand begins to support DElems
 	}
+
+	public function test_008_manual_ids()
+	{
+		Assert.same(
+			expand(DElemList([
+				@id("a")@wrap(8,0)DVolume(1,@len(1)Word("a"),@skip(1)DElemList([DParagraph(@len(1)Word("b")),
+				@skip(8)@id("foo")@wrap(9,0)DChapter(1,@len(1)Word("c"),@skip(1)DParagraph(@len(1)Word("d")))])),
+				@skip(8)@id("bar")@wrap(8,0)DVolume(2,@len(1)Word("e"),@skip(1)DElemList([DParagraph(@len(1)Word("f")),
+				//VOL!=ChaptersowhenIchangethevolIcantchangechapter#
+				@id("g")@wrap(9,0)DChapter(2,@len(1)Word("g"),@skip(1)DParagraph(@len(1)Word("h")))]))
+			])),
+			parse("\\volume{a}b\\id{foo}\\chapter{c}d\\id{bar}\\volume{e}f\\chapter{g}h"));
+	}
 }
+
 

--- a/generator/src/tex/Generator.hx
+++ b/generator/src/tex/Generator.hx
@@ -105,6 +105,10 @@ class Generator {
 			return '\\code{${gent(code)}}';
 		case Math(tex):
 			return '$$$tex$$';
+		case Ref(_):
+			return '';  // FIXME:xref
+		case RangeRef(_):
+			return '';  // FIXME:xref
 		case HElemList(li):
 			var buf = new StringBuf();
 			for (i in li)

--- a/generator/src/tex/LargeTable.hx
+++ b/generator/src/tex/LargeTable.hx
@@ -35,6 +35,7 @@ class LargeTable {
 		case Superscript(i), Subscript(i): Math.round(pseudoHTypeset(i)*SUBTEXT_FACTOR);
 		case Emphasis(i), Highlight(i): pseudoHTypeset(i);
 		case Word(w), InlineCode(w), Math(w): w.length;
+		case Ref(_), RangeRef(_): 0;  // FIXME:xref
 		case HElemList(li):
 			var cnt = 0;
 			for (i in li)

--- a/generator/src/transform/Context.hx
+++ b/generator/src/transform/Context.hx
@@ -43,6 +43,27 @@ private class DocumentContext<T> {
 		function set_subSubSection(v)
 			return subSubSection = v;
 
+	/*
+	Complete missing components from another context.
+
+	Modifies this context in place.
+	*/
+	public function completeFrom(other:DocumentContext<T>)
+	{
+		// TODO reimplement with a macro to prevent bugs
+		if (volume == null && other.volume != volume) volume = other.volume;
+		if (chapter == null && other.chapter != chapter) chapter = other.chapter;
+		if (section == null && other.section != section) section = other.section;
+		if (subSection == null && other.subSection != subSection) subSection = other.subSection;
+		if (subSubSection == null && other.subSubSection != subSubSection) subSubSection = other.subSubSection;
+		if (box == null && other.box != box) box = other.box;
+		if (figure == null && other.figure != figure) figure = other.figure;
+		if (table == null && other.table != table) table = other.table;
+	}
+
+	/*
+	Stringify into a string by joining all components.
+	*/
 	public macro function join(ethis:Expr, prefix:Bool, separator:String, fields:Array<Expr>)
 	{
 		var comp = [];

--- a/generator/src/transform/NewTransform.hx
+++ b/generator/src/transform/NewTransform.hx
@@ -32,7 +32,7 @@ class NewTransform {
 			h = mk(Emphasis(htrim(i, ctx)), h.pos);
 		case Highlight(i):
 			h = mk(Highlight(htrim(i, ctx)), h.pos);
-		case Word(_), InlineCode(_), Math(_):
+		case Word(_), InlineCode(_), Math(_), Ref(_), RangeRef(_):
 			ctx.prevSpace = false;
 		case HElemList(li):
 			if (ctx.reverse) {
@@ -55,7 +55,7 @@ class NewTransform {
 	static function hclean(h:HElem)
 	{
 		var def = switch h.def {
-		case Wordspace, Word(_), InlineCode(_), Math(_), HEmpty:
+		case Wordspace, Word(_), InlineCode(_), Math(_), Ref(_), RangeRef(_), HEmpty:
 			h.def;
 		case Superscript(i):
 			i = hclean(i);
@@ -111,6 +111,8 @@ class NewTransform {
 		case HElemList(li):
 			for (i in li)
 				buf.add(genId(i));
+		case Ref(_), RangeRef(_):
+			buf.add("ref");  // FIXME:xref
 		case HEmpty:
 			// NOOP
 		}

--- a/generator/src/transform/NewTransform.hx
+++ b/generator/src/transform/NewTransform.hx
@@ -121,7 +121,11 @@ class NewTransform {
 	{
 		var li = [];
 		while (pool.length > 0) {
-			switch [parent.def, pool[0].def] {
+			var peek = switch pool[0].def {
+				case Id(_, elem): elem.def;
+				case other: other;
+				}
+			switch [parent.def, peek] {
 			case [Volume(_), Volume(_)]: break;
 			case [Chapter(_), Chapter(_)|Volume(_)]: break;
 			case [Section(_), Section(_)|Chapter(_)|Volume(_)]: break;
@@ -159,12 +163,9 @@ class NewTransform {
 			case other: throw other;
 			}
 			return mkd(DEmpty, v.pos);
-		case Id(val):
-			return mkd(DEmpty, v.pos);
-			// assert(siblings.length > 0, "must apply Id to something", "TODO typeded error");
-			// var elem = siblings.shift();
-			// assert(elem.def.match(Volume(_)|Chapter(_)|Section(_)|SubSection(_)|SubSubSection(_)|Figure(_)|Table(_)|ImgTable(_)|Box(_)), "invalid elem to apply Id to", "TODO typeded error");
-			// return vertical(elem, siblings, idc, noc, val.def);
+		case Id(val, elem):
+			assert(elem.def.match(Volume(_)|Chapter(_)|Section(_)|SubSection(_)|SubSubSection(_)|Figure(_)|Table(_)|ImgTable(_)|Box(_)), "invalid elem to apply Id to", "TODO typeded error");
+			return vertical(elem, siblings, idc, noc, val.def);
 		case Volume(horizontal(_) => name):
 			var id = idc.volume = withId != null ? withId : genId(name);
 			var no = noc.volume = noc.lastVolume + 1;

--- a/generator/src/transform/Validator.hx
+++ b/generator/src/transform/Validator.hx
@@ -137,6 +137,10 @@ class Validator {
 		case HElemList(li):
 			for (i in li)
 				hiter(i);
+		case Ref(_):
+			// TODO:xref
+		case RangeRef(_):
+			// TODO:xref
 		case Wordspace, Word(_), InlineCode(_), HEmpty:
 			// nothing to do
 		}

--- a/guide/01-project-initiation-and-set-up/11project-catalyst.src
+++ b/guide/01-project-initiation-and-set-up/11project-catalyst.src
@@ -23,7 +23,7 @@ of many systems is often not part of the political agenda. Instead, the impetus 
 customers and citizen groups who are closer to the day-to-day realities. In some instances, public transport 
 customers have formed their own organizations to demand improved conditions. In Los Angeles, the Bus 
 Riders Union has successfully launched several campaigns to convince decision makers to expand bus-priority 
-lanes, as well as to modernize the vehicle fleet (Figure 1.2). In Bogotá, Colombia, “user leagues” of 
+lanes, as well as to modernize the vehicle fleet \ref{figure:la-bus-riders-union}. In Bogotá, Colombia, “user leagues” of 
 various types have been created by citizens in recent years to constructively criticize their BRT and 
 its operations, and in many cases this has resulted in improvements to the system.
 

--- a/guide/01-project-initiation-and-set-up/11project-catalyst.src
+++ b/guide/01-project-initiation-and-set-up/11project-catalyst.src
@@ -27,6 +27,7 @@ lanes, as well as to modernize the vehicle fleet (Figure 1.2). In Bogotá, Colom
 various types have been created by citizens in recent years to constructively criticize their BRT and 
 its operations, and in many cases this has resulted in improvements to the system.
 
+\id{la-bus-riders-union}
 \figure{assets/image2.jpeg}{The Los Angeles Bus Riders Union has proved that people power can catalyze 
 more progressive policies.}{Bus Riders Union.}
 


### PR DESCRIPTION
I had hoped to push something functional by Xmas, but I ended up working on the new server...

Still, I'm opening the pull request as is to get the tests to run (and to track the development).

 - manual ids with `\id{<id>}`:
    + [x] spec/design
    + [x] parse
    + [x] apply to the structured document
    + [x] update the generators
    + [ ] enforce syntax rules at the parser and/or validator
 - cross references with `\ref[<optional type>]{<id>}` and `\rangeref[<optinal type>]{<id>}`
    + [x] spec/design
    + [ ] parse
    + [ ] pass through the structuring
    + [ ] implement the resolution algorithm
    + [ ] html references
    + [ ] tex/pdf references
    + [ ] enforce syntax rules at the parser and/or validator
    + [ ] check ref resolution at the validator
 - usage examples