### PR TITLE
Makes equations zoomable

### DIFF
--- a/generator/src/html/Generator.hx
+++ b/generator/src/html/Generator.hx
@@ -380,8 +380,8 @@ class Generator {
 			return '<pre><code>${gent(code)}</code></pre>\n';
 		case DQuotation(text, by):
 			return '<blockquote class="md"><q>${genh(text)}</q><span class="by">${genh(by)}</span></blockquote>\n';
-        case DParagraph({pos:p, def:Math(tex)}):
-            return '<p${genp(v.pos)}><span class="mathjax zoomable"${genp(p)}>\\[${gent(tex)}\\]</span></p>\n';
+		case DParagraph({pos:p, def:Math(tex)}):
+			return '<p${genp(v.pos)}><span class="mathjax equation"${genp(p)}>\\[${gent(tex)}\\]</span></p>\n';
 		case DParagraph(h):
 			return '<p${genp(v.pos)}>${genh(h)}</p>\n';
 		case DElemList(li):

--- a/generator/src/html/Generator.hx
+++ b/generator/src/html/Generator.hx
@@ -381,7 +381,7 @@ class Generator {
 		case DQuotation(text, by):
 			return '<blockquote class="md"><q>${genh(text)}</q><span class="by">${genh(by)}</span></blockquote>\n';
         case DParagraph({pos:p, def:Math(tex)}):
-            return '<p${genp(v.pos)}><span class="mathjax"${genp(p)}>\\[${gent(tex)}\\]</span></p>\n';
+            return '<p${genp(v.pos)}><span class="mathjax zoomable"${genp(p)}>\\[${gent(tex)}\\]</span></p>\n';
 		case DParagraph(h):
 			return '<p${genp(v.pos)}>${genh(h)}</p>\n';
 		case DElemList(li):

--- a/generator/src/html/renderHead.tt
+++ b/generator/src/html/renderHead.tt
@@ -8,12 +8,24 @@
 <!-- Jquery -->
 <script src = "https://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js" ></script>
 <!-- MathJax -->
+<!-- FIXME! zoom attributes shall be inheritable from guide/*css, if styles are not here in config, MathJax.js create/overide (his) default styles -->
+<!-- By now, concentrating all styles here. Also filter (blur) seems to require a div (it does not work on span, so the setting here is useless -->
+<!-- Beware when testing: if you use MathJax menu to set the trigger, it overrides the settings in the menuSettings... remove  mjx.menu cookie -->
 <script type="text/x-mathjax-config">
-	MathJax.Hub.Config({
+    MathJax.Hub.Config({
 		tex2jax: {
 			ignoreClass: ".+",
 			processClass: "mathjax"
-		}
+		},
+        menuSettings:{
+            zoom: "Click"
+        },
+        MathZoom: {
+            styles: {
+            "#MathJax_Zoom":{"z-index":"1000","cursor":"zoom-out" },
+            "#MathJax_ZoomOverlay": {"opacity":"0.75","background":"rgba(127,127,127,0.75)","z-index":"999","cursor":"zoom-out","filter":"blur(3px) grayscale(.5)" }
+            }
+        }
 	});
 </script>
 <script async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML" ></script>

--- a/generator/src/html/renderHead.tt
+++ b/generator/src/html/renderHead.tt
@@ -8,25 +8,25 @@
 <!-- Jquery -->
 <script src = "https://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js" ></script>
 <!-- MathJax -->
-<!-- FIXME! zoom attributes shall be inheritable from guide/*css, if styles are not here in config, MathJax.js create/overide (his) default styles -->
-<!-- By now, concentrating all styles here. Also filter (blur) seems to require a div (it does not work on span, so the setting here is useless -->
-<!-- Beware when testing: if you use MathJax menu to set the trigger, it overrides the settings in the menuSettings... remove  mjx.menu cookie -->
+<!-- FIXME styling here instead of client css because of MathZoom inner workings -->
+<!-- FIXME missing blur on out of focus elements; can use "math zoomed" and "math unzommed" events but need a different structure -->
+<!-- BEWARE when testing: if you use MathJax menu to set the trigger, it overrides the settings in the menuSettings... if necessary, remove the mjx.menu cookie -->
 <script type="text/x-mathjax-config">
-    MathJax.Hub.Config({
-		tex2jax: {
-			ignoreClass: ".+",
-			processClass: "mathjax"
-		},
-        menuSettings:{
-            zoom: "Click"
-        },
-        MathZoom: {
-            styles: {
-            "#MathJax_Zoom":{"z-index":"1000","cursor":"zoom-out" },
-            "#MathJax_ZoomOverlay": {"opacity":"0.75","background":"rgba(127,127,127,0.75)","z-index":"999","cursor":"zoom-out","filter":"blur(3px) grayscale(.5)" }
-            }
-        }
-	});
+MathJax.Hub.Config({
+  tex2jax: {
+    ignoreClass: ".+",
+    processClass: "mathjax"
+  },
+  menuSettings:{
+    zoom: "Click"
+  },
+  MathZoom: {
+    styles: {
+      "#MathJax_Zoom":{"z-index":"1000","cursor":"pointer","cursor":"zoom-out" },
+      "#MathJax_ZoomOverlay": {"opacity":"0.75","background":"rgba(127,127,127,0.75)","z-index":"999","cursor":"pointer","cursor":"zoom-out" }
+    }
+  }
+});
 </script>
 <script async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML" ></script>
 <!-- Google Fonts -->

--- a/guide/style.css
+++ b/guide/style.css
@@ -303,6 +303,11 @@ td ul, th ul, td ol, th ol {
 
 /* equation */
 
+.zoomable {
+	cursor:zoom-in;
+}
+
+
 .equation {
 	padding: 24px 0;
 	background-color: #EEE;

--- a/guide/style.css
+++ b/guide/style.css
@@ -303,16 +303,9 @@ td ul, th ul, td ol, th ol {
 
 /* equation */
 
-.zoomable {
-	cursor:zoom-in;
-}
-
-
 .equation {
-	padding: 24px 0;
-	background-color: #EEE;
-	border-radius: 2px;
-	font-size: 150%;
+	cursor: pointer;
+	cursor: zoom-in;
 }
 
 /* quotes */


### PR DESCRIPTION
I am not sure this is to merge: it works, but 
- Zoom is not uniform with figures, it does not blur the background
- Style is on the MathJax Config header and not on the proper css
(it could be split, but it would add confusion)

Visual hint about it (zoom-in cursor) on display-math only
Zoomable was created because class .MJXc-display spans the page width
