### PR TITLE
Support vertical elements in quotation text [manu]

### DIFF
--- a/generator/src/html/Generator.hx
+++ b/generator/src/html/Generator.hx
@@ -441,7 +441,16 @@ class Generator {
 		case DCodeBlock(code):
 			return '<pre><code>${gent(code)}</code></pre>\n';
 		case DQuotation(text, by):
-			return '<blockquote class="md"><q>${genh(text)}</q><span class="by">${genh(by)}</span></blockquote>\n';
+			return
+				switch text.def {
+				case DParagraph(htext):
+					'<blockquote class="md"><q>${genh(htext)}</q><span class="by">${genh(by)}</span></blockquote>\n';
+				case DElemList(li) if (Lambda.foreach(li, function (i) return i.def.match(DParagraph(_)))):
+					var pars = [for (i in li) switch i.def { case DParagraph(text): genh(text); case _: assert(false); null; }];
+					'<blockquote class="md"><q>${pars.join("</q><q>")}</q><span class="by">${genh(by)}</span></blockquote>\n';
+				case _:
+					assert(false, "TODO: can't generate quotations with arbitrary vertical elements yet"); "";
+				}
 		case DParagraph({pos:p, def:Math(tex)}):
 			return '<p${genp(v.pos)}><span class="mathjax equation"${genp(p)}>\\[${gent(tex)}\\]</span></p>\n';
 		case DParagraph(h):

--- a/generator/src/parser/Ast.hx
+++ b/generator/src/parser/Ast.hx
@@ -94,7 +94,7 @@ enum VDef {
 	Figure(size:BlobSize, path:PElem, caption:HElem, copyright:HElem);
 	Table(size:BlobSize, caption:HElem, header:TableRow, rows:Array<TableRow>);  // copyright/source?
 	ImgTable(size:BlobSize, caption:HElem, path:PElem);  // copyright/source?
-	Quotation(text:HElem, by:HElem);
+	Quotation(text:VElem, by:HElem);
 	List(numered:Bool, items:Array<VElem>);
 	Box(name:HElem, contents:VElem);
 	CodeBlock(c:String);

--- a/generator/src/parser/Parser.hx
+++ b/generator/src/parser/Parser.hx
@@ -359,7 +359,7 @@ class Parser {
 	function quotation(cmd:Token)
 	{
 		assert(cmd.def.match(TCommand("quotation")), cmd);
-		var text = arg(hlist, cmd, "text");
+		var text = arg(vlist.bind(_, true), cmd, "text");
 		var author = arg(hlist, cmd, "author");
 		return mk(Quotation(text.val, author.val), cmd.pos.span(author.pos));
 	}

--- a/generator/src/tests/Test_03_Parser.hx
+++ b/generator/src/tests/Test_03_Parser.hx
@@ -269,10 +269,10 @@ class Test_03_Parser {
 	public function test_011_quotations()
 	{
 		Assert.same(
-			expand(@wrap(11,1)Quotation(@len(1)Word("a"),@skip(2)@len(1)Word("b"))),  // FIXME @skip
+			expand(@wrap(11,1)Quotation(Paragraph(@len(1)Word("a")),@skip(2)@len(1)Word("b"))),  // FIXME @skip
 			parse("\\quotation{a}{b}"));
 		Assert.same(
-			expand(@wrap(12,1)Quotation(@len(1)Word("a"),@skip(3)@len(1)Word("b"))),  // FIXME @skip
+			expand(@wrap(12,1)Quotation(Paragraph(@len(1)Word("a")),@skip(3)@len(1)Word("b"))),  // FIXME @skip
 			parse("\\quotation\n{a}\n{b}"));
 
 		fails("\\quotation", MissingArgument(TCommand("quotation"), "text"), mkPos(10, 10));

--- a/generator/src/tests/Test_05_Transform.hx
+++ b/generator/src/tests/Test_05_Transform.hx
@@ -353,8 +353,8 @@ class Test_05_Transform {
 			transform(expand(List(true, [Paragraph(Word("a")), Paragraph(Word("b"))]))));
 		Assert.same(expand(DCodeBlock("a")),
 			transform(expand(CodeBlock("a"))));
-		Assert.same(expand(DQuotation(Word("a"), Word("b"))),
-			transform(expand(Quotation(Word("a"), Word("b")))));
+		Assert.same(expand(DQuotation(DParagraph(Word("a")), Word("b"))),
+			transform(expand(Quotation(Paragraph(Word("a")), Word("b")))));
 		Assert.same(expand(DParagraph(HElemList([Word("a")]))),
 			transform(expand(Paragraph(HElemList([Word("a")])))));
 		// TODO improve when expand begins to support DElems

--- a/generator/src/tex/Generator.hx
+++ b/generator/src/tex/Generator.hx
@@ -228,7 +228,7 @@ class Generator {
 			show("code blocks in TeX improperly implemented");
 			return '\\begincode\n${gent(code)}\n\\endcode\n${genp(v.pos)}\n';
 		case DQuotation(text, by):
-			return '\\quotation{${genh(text)}}{${genh(by)}}\n${genp(v.pos)}\n';
+			return '\\quotation{${genv(text, at, idc)}}{${genh(by)}}\n${genp(v.pos)}\n';
 		case DParagraph({pos:p, def:Math(tex)}):
 			return '\\[$tex\\]';
 		case DParagraph(h):

--- a/generator/src/tex/LargeTable.hx
+++ b/generator/src/tex/LargeTable.hx
@@ -57,7 +57,7 @@ class LargeTable {
 			cnt/li.length;
 		case DFigure(_, _, _, caption, cright): TBL_MARK_COST + pseudoHTypeset(caption) + SPACE_COST + pseudoHTypeset(cright);
 		case DTable(_), DImgTable(_), DBox(_): BAD_COST; // not allowed (for now?) FIXME review
-		case DQuotation(text, by): QUOTE_COST + pseudoHTypeset(text) + QUOTE_COST + LINE_BREAK_COST + EM_DASH_COST + pseudoHTypeset(by);
+		case DQuotation(text, by): QUOTE_COST + pseudoTypeset(text) + QUOTE_COST + LINE_BREAK_COST + EM_DASH_COST + pseudoHTypeset(by);
 		case DList(numbered, li):
 			var markCost = BULLET_COST + SPACE_COST;
 			if (numbered)

--- a/generator/src/transform/NewDocument.hx
+++ b/generator/src/transform/NewDocument.hx
@@ -29,7 +29,7 @@ enum DDef {
 	DImgTable(no:Int, size:BlobSize, caption:HElem, path:PElem);
 	DList(numbered:Bool, li:Array<DElem>);
 	DCodeBlock(cte:String);
-	DQuotation(text:HElem, by:HElem);
+	DQuotation(text:DElem, by:HElem);
 	DParagraph(text:HElem);
 
 	DElemList(li:Array<DElem>);  // TODO rename avoiding confusion with (un)numbered lists

--- a/generator/src/transform/NewTransform.hx
+++ b/generator/src/transform/NewTransform.hx
@@ -214,7 +214,7 @@ class NewTransform {
 		case CodeBlock(cte):
 			return mkd(DCodeBlock(cte), v.pos);
 		case Quotation(text, by):
-			return mkd(DQuotation(horizontal(text), horizontal(by)), v.pos);
+			return mkd(DQuotation(vertical(text, siblings, idc, noc), horizontal(by)), v.pos);
 		case Paragraph(text):
 			return mkd(DParagraph(horizontal(text)), v.pos);
 		case VElemList(li):

--- a/generator/src/transform/Validator.hx
+++ b/generator/src/transform/Validator.hx
@@ -181,6 +181,15 @@ class Validator {
 		return true;
 	}
 
+	function notDEmpty(h:DElem, parent:DElem, name:String)
+	{
+		if (h.def.match(DEmpty)) {
+			errors.push(new ValidationError(h.pos, BlankValue(elemDesc(parent), name)));
+			return false;
+		}
+		return true;
+	}
+
 	/*
 	Validate document elements.
 
@@ -219,8 +228,8 @@ class Validator {
 				hiter(caption);
 			push(validateSrcPath(path, [Jpeg, Png]));
 		case DQuotation(text, by):
-			if (notHEmpty(text, d, "text"))
-				hiter(text);
+			if (notDEmpty(text, d, "text"))
+				diter(text);
 			if (notHEmpty(by, d, "author"))
 				hiter(by);
 		case DParagraph(text):

--- a/guide/preamble.tex
+++ b/guide/preamble.tex
@@ -255,7 +255,9 @@
 \fi
 
 %quotation {quote}{name, about, 1900 - 2000}
-\renewcommand{\quotation}[2]{\begingroup\leftskip=14mm\rightskip=14mm {\small\color{gray50} \noindent\textit{``#1''} \\\hbox{}\hfill --- #2} \par\endgroup \smallskip }
+%FIXME incorrect placement of closing quotations; #1 already ends in \par
+%FIXME incorrect indentation if more than one element in #1
+\renewcommand{\quotation}[2]{\begingroup\leftskip=14mm\rightskip=14mm {\small\color{gray50} \noindent\itshape``#1'' \\\hbox{}\hfill --- #2} \par\endgroup \smallskip }
 
 %tables
 %note: \tablemodule*46*2 must match \textwidth+\marginparsep+\marginparwidth

--- a/guide/style.css
+++ b/guide/style.css
@@ -370,7 +370,6 @@ blockquote {
 blockquote .by {
 	display: block;
 	text-align: right;
-	margin-top: 8px;
 }
 blockquote .by::before {
 	content: "— ";
@@ -380,10 +379,15 @@ blockquote.md {
 	padding: 16px;
 	margin: 32px 0;
 }
-q {
+blockquote q {
 	quotes: "“" "”" "‘" "’";
 	font-style: italic;
+	display: block;
+	margin-bottom: 8px;
 }
+blockquote q::before, blockquote q::after { content: ""; }
+blockquote q:first-of-type::before { content: open-quote; }
+blockquote q:last-of-type::after { content: close-quote; }
 
 /* boxes */
 


### PR DESCRIPTION
To do:

 - [x] change the AST from `Quotation(HElem,HElem)` to `Quotation(VElem,HElem)`:
 - [x] propagate this through structuring and validation
 - [x] implement simplified HTML generation (paragraphs only)
 - [x] update the TeX generation
 - [x] update the stylesheet for the guide
 - [ ] update the TeX preamble used by the guide
 - [ ] implement complete HTML generation of the new AST, adding support for the
       remaining (restricted mode) vertical elements