### PR TITLE
Switch the math validation engine to KaTeX

### DIFF
--- a/generator/extern/katex/Katex.hx
+++ b/generator/extern/katex/Katex.hx
@@ -1,0 +1,17 @@
+package katex;
+
+typedef Options = {
+	?displayMode:Bool,  // default: false
+	?throwOnError:Bool,  // default:true
+	?errorColor:String  // default: #cc0000
+}
+
+#if nodejs
+@:jsRequire("katex")
+#elseif !js
+#error "Katex requires a JS runtime.  For Node.js, you also need `-lib hxnodejs`."
+#end
+extern class Katex {
+	public static function renderToString(tex:String, ?opts:Options):String;
+}
+

--- a/generator/package.json
+++ b/generator/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/ITDP/the-online-brt-planning-guide/tree/master/generator",
   "dependencies": {
+    "katex": "^0.7.1",
     "mathjax-node": "0.*.*",
     "source-map-support": ""
   }
 }
-

--- a/generator/src/transform/Validator.hx
+++ b/generator/src/transform/Validator.hx
@@ -54,37 +54,17 @@ class Validator {
 
 #if nodejs
 	/*
-	Initialize and configure MathJax, but only once.
-	*/
-	dynamic function initMathJax()
-	{
-		mathjax.Single.config({
-			displayMessages : false,
-			displayErrors : false,
-			undefinedCharError : true
-		});
-		this.initMathJax = function () {};
-	}
-
-	/*
 	Validate TeX math.
 	*/
 	function validateMath(tex:String, pos:Position)
 	{
 		if (Context.noMathValidation) return;
 
-		wait++;
-		initMathJax();
-		mathjax.Single.typeset({
-			math:tex,
-			format:mathjax.Single.SingleTypesetFormat.TEX,
-			mml:true
-		}, function (res) {
-			if (res.errors != null)
-				errors.push(new ValidationError(pos, BadMath(tex, res.errors)));
-			wait--;
-			tick();
-		});
+		try {
+			katex.Katex.renderToString(tex);
+		} catch (err:Dynamic) {
+			push(new ValidationError(pos, BadMath(tex, [err])));
+		}
 	}
 #else
 	/*


### PR DESCRIPTION
Related to #101; [initial experiment results](https://github.com/ITDP/the-online-brt-planning-guide/issues/101#issuecomment-308629093)

I still haven't been able to make that patch pass the unit tests and existing math in the Guide.

So, at the moment, this is incomplete and hard to fix.  Still, I'm creating the pull request to properly archive this patch.