### PR TITLE
CSS: media query print

### DIFF
--- a/guide/style.css
+++ b/guide/style.css
@@ -643,7 +643,7 @@ figcaption.share:hover:after {
 
 /* responsive */
 
-@media (max-width: 1239px) {
+@media screen and (max-width: 1239px) {
 	body {
 		margin: 20px;
 	}
@@ -813,4 +813,16 @@ figcaption.share:hover:after {
 		display: none;
 	}
 
+}
+
+/* print */
+@media print {
+	header, nav, #toc, .navigation { display: none !important; }
+	.tocfull { display: block; }
+	.col-text {
+		margin: 0 auto;
+		float: left;
+		width: 928px;
+		padding-bottom: 0;
+	}
 }


### PR DESCRIPTION
`.css` media query for printing `.html`.

before:

![040](https://user-images.githubusercontent.com/5419183/28021109-21c78f22-655d-11e7-9673-b253ae36f5f0.PNG)

and after (with `@media print`):

![041](https://user-images.githubusercontent.com/5419183/28021126-316f2d90-655d-11e7-9b5d-b16480046fc1.PNG)