### PR TITLE
CSS: lists

### DIFF
--- a/guide/style.css
+++ b/guide/style.css
@@ -517,7 +517,7 @@ q::after {
 
 /* lists */
 
-section > ul,ol {
+section > ul, section > ol {
 	padding-left: 32px;
 	width: 576px;
 	font-family: 'PT Serif', serif;

--- a/guide/style.css
+++ b/guide/style.css
@@ -523,6 +523,13 @@ section > ul, section > ol {
 	font-family: 'PT Serif', serif;
 	text-align: justify;
 }
+section ol ol, section ol ul, section ul ol, section ul ul {
+    padding-left: 16px;
+    text-align: justify;
+}
+section ul {
+	list-style: disc;
+}
 
 /* code */
 

--- a/guide/style.css
+++ b/guide/style.css
@@ -527,9 +527,6 @@ section ol ol, section ol ul, section ul ol, section ul ul {
     padding-left: 16px;
     text-align: justify;
 }
-section ul {
-	list-style: disc;
-}
 
 /* code */
 

--- a/guide/style.css
+++ b/guide/style.css
@@ -519,13 +519,16 @@ q::after {
 
 section > ul, section > ol {
 	padding-left: 32px;
-	width: 576px;
+	width: 608px;
 	font-family: 'PT Serif', serif;
 	text-align: justify;
 }
 section ol ol, section ol ul, section ul ol, section ul ul {
-    padding-left: 16px;
-    text-align: justify;
+	padding-left: 16px;
+  text-align: justify;
+}
+section ul {
+	list-style: disc;
 }
 
 /* code */


### PR DESCRIPTION
[Issue #165](https://github.com/ITDP/the-online-brt-planning-guide/issues/165): "markers for (numbered/unnumbered) lists under heavy nesting"

[4.5.2 (master)](https://brtguide.itdp.org/branch/master/guide/demand-analysis/estimating-demand-using-a-full-transport-model#sub-models)
[4.5.2 (PR#204)](https://brtguide.itdp.org/pull_request/204/guide/demand-analysis/estimating-demand-using-a-full-transport-model#sub-models)