### PR TITLE
CSS: DTitle

### DIFF
--- a/generator/src/html/Generator.hx
+++ b/generator/src/html/Generator.hx
@@ -343,8 +343,7 @@ class Generator {
 				</section>
 			'.doctrim() + "\n";
 		case DTitle(name):
-			// FIXME
-			return genv({ def:DParagraph({ def:Highlight(name), pos:v.pos }), pos:v.pos, id:v.id }, idc, noc, bcs);
+			return '<h3>${genh(name)}</h3>';
 		case DFigure(no, size, _.toInputPath() => path, caption, cright):
 			idc.figure = v.id.sure();
 			noc.figure = no;

--- a/guide/style.css
+++ b/guide/style.css
@@ -25,19 +25,15 @@ html {
 
 /* headings */
 
-h1, h2, h3, h4, h5, h6 {
+h1, h2, h3 {
 	font-family: 'PT Sans', sans-serif;
 	font-weight: bold;
 	color: #666;
-	margin: 32px 0 16px 0;
 	max-width: 640px;
 }
-h1 { font-size: 32px; }
-h2 { font-size: 20px; }
-h3 { font-size: 16px; }
-h4 { font-size: 20px; }
-h5 { font-size: 16px; }
-h6 { font-size: 16px; }
+h1 { font-size: 32px; margin: 32px 0 16px; }
+h2 { font-size: 20px; margin: 32px 0 16px; }
+h3 { font-size: 16px; margin: 16px 0; }
 .brtcolor {
 	color: #00a95e;
 }


### PR DESCRIPTION
[Issue #165](https://github.com/ITDP/the-online-brt-planning-guide/issues/165): "properly style DTitle output (currently proxied by DParagraph(Highlight(...)))"

[1.5.1 (master)](https://brtguide.itdp.org/branch/master/guide/project-initiation/understanding-and-presenting-the-benefits#listing-of-benefits-commonly-sought-with-major-public-transport-projects)
[1.5.1 (PR#205)](https://brtguide.itdp.org/pull_request/205/guide/project-initiation/understanding-and-presenting-the-benefits#listing-of-benefits-commonly-sought-with-major-public-transport-projects)